### PR TITLE
glibc: security update to fix a pointer guarding weakness

### DIFF
--- a/core-libs/glibc/autobuild/patches/0001-Ignore-LD_POINTER_GUARD-for-set-user-ID-set-group-ID.patch
+++ b/core-libs/glibc/autobuild/patches/0001-Ignore-LD_POINTER_GUARD-for-set-user-ID-set-group-ID.patch
@@ -1,0 +1,81 @@
+From 2edd5f5fddd97b7ac7adb1e7125afe434549d85d Mon Sep 17 00:00:00 2001
+From: Hector Marco-Gisbert <hecmargi@upv.es>
+Date: Sat, 5 Sep 2015 18:27:01 +0200
+Subject: [PATCH] Ignore LD_POINTER_GUARD for set-user-ID/set-group-ID
+ binaries.
+
+Hello,
+
+A weakness in the dynamic loader have been found, Glibc prior to
+2.22.90 are affected. The issue is that the LD_POINTER_GUARD in the
+environment is not sanitized allowing local attackers easily to bypass
+the pointer guarding protection on set-user-ID and set-group-ID
+programs. 
+
+Details of the weakness:
+http://hmarco.org/bugs/glibc_ptr_mangle_weakness.html
+
+This patch prevents to disable the pointer guarding protection for
+set-user-ID/set-group-ID programs.
+
+For example, executing "LD_POINTER_GUARD=0 /bin/ping" does not disable
+the pointer guarding protection unless it is directly executed by root
+(rUID==eUID).
+
+
+Signed-off-by: Hector Marco-Gisbert <hecmargi@upv.es>
+Signed-off-by: Ismael Ripoll Ripoll <iripoll@upv.es>
+---
+ ChangeLog                   | 11 +++++++++++
+ elf/rtld.c                  |  3 ++-
+ sysdeps/generic/unsecvars.h |  1 +
+ 3 files changed, 14 insertions(+), 1 deletion(-)
+
+diff --git a/ChangeLog b/ChangeLog
+index 53b6c24..3c799ec 100644
+--- a/ChangeLog
++++ b/ChangeLog
+@@ -1,3 +1,14 @@
++2015-08-31  Hector Marco-Gisbert  <hemcargi@upv.es>
++            Ismael Ripoll Ripoll <iripoll@upv.es>
++
++	* elf/rtld.c: Ignore LD_POINTER_GUARD for set-user-ID/set-group-ID
++	binaries. Otherwise an attacker can disable the pointer guarding
++	protection when attacking set-user-ID/set-group-ID binaries
++	locally.
++	* sysdeps/generic/unsecvars.h: Added LD_POINTER_GUARD environment
++	variable to UNSECURE_ENVVARS list to remove it from environment of
++	SUID binaries.
++
+ 2015-09-04  Roland McGrath  <roland@hack.frob.com>
+ 
+ 	[BZ #18921]
+diff --git a/elf/rtld.c b/elf/rtld.c
+index 69873c2..abdc1a2 100644
+--- a/elf/rtld.c
++++ b/elf/rtld.c
+@@ -2472,7 +2472,8 @@ process_envvars (enum mode *modep)
+ 	      break;
+ 	    }
+ 
+-	  if (memcmp (envline, "POINTER_GUARD", 13) == 0)
++	  if (!__libc_enable_secure
++	      && memcmp (envline, "POINTER_GUARD", 13) == 0)
+ 	    GLRO(dl_pointer_guard) = envline[14] != '0';
+ 	  break;
+ 
+diff --git a/sysdeps/generic/unsecvars.h b/sysdeps/generic/unsecvars.h
+index d5b8119..9f1946a 100644
+--- a/sysdeps/generic/unsecvars.h
++++ b/sysdeps/generic/unsecvars.h
+@@ -11,6 +11,7 @@
+   "LD_DYNAMIC_WEAK\0"							      \
+   "LD_LIBRARY_PATH\0"							      \
+   "LD_ORIGIN_PATH\0"							      \
++  "LD_POINTER_GUARD\0"							      \
+   "LD_PRELOAD\0"							      \
+   "LD_PROFILE\0"							      \
+   "LD_SHOW_AUXV\0"							      \
+-- 
+1.9.1
+

--- a/core-libs/glibc/spec
+++ b/core-libs/glibc/spec
@@ -1,3 +1,3 @@
 VER=2.22
-REL=1
+REL=2
 SRCTBL="http://ftp.gnu.org/gnu/glibc/glibc-$VER.tar.xz"


### PR DESCRIPTION
Source: http://hmarco.org/bugs/glibc_ptr_mangle_weakness.html

A weakness in the dynamic loader have been found, Glibc prior to
2.22.90 are affected. The issue is that the LD_POINTER_GUARD in
the environment is not sanitized allowing local attackers easily
to bypass the pointer guarding protection on set-user-ID and
set-group-ID programs.

Pointer guarding is a security mechanism whereby some pointers
to code stored in writable program memory (return addresses saved
by setjmp(3) or function pointers used by various glibc internals)
are mangled semi-randomly to make it more difficult for an
attacker to hijack the pointers for use in the event of a buffer
overrun or stack-smashing attack.

patch: 0001-Ignore-LD_POINTER_GUARD-for-set-user-ID-set-group-ID.patch
