### PR TITLE
core: add mips64el support and fix several bugs

### DIFF
--- a/core-devel/gcc/01-runtime/defines
+++ b/core-devel/gcc/01-runtime/defines
@@ -68,9 +68,10 @@ if [[ "${CROSS:-$ARCH}" = *cross* ]]; then
 fi
 
 # MIPS is not yet happy with GNU hashing style.
-if [[ "${CROSS:-$ARCH}" != mips* ]]; then
-    AUTOTOOLS_AFTER+=" --with-linker-hash-style=gnu"
-fi
+# Really?
+#if [[ "${CROSS:-$ARCH}" != mips* ]]; then
+#    AUTOTOOLS_AFTER+=" --with-linker-hash-style=gnu"
+#fi
 
 # ARM and AArch64 specific.
 if [[ "${CROSS:-$ARCH}" = arm* ]]; then
@@ -99,6 +100,11 @@ if [[ "${CROSS:-$ARCH}" = "ppc64" ]]; then
     AUTOTOOLS_AFTER+=" --with-cpu=620 --with-tune=G5 \
                        --with-long-double-128 --enable-secureplt"
 fi
+
+# MIPS64EL specific.
+if [[ "${CROSS:-$ARCH}" = "mips64el" ]]; then
+    AUTOTOOLS_AFTER+=" --with-abi=64 --with-arch=mips64r2 \
+                       --with-tune=loongson3a" 
 
 # Use profiledbootstrap.
 ABMK="profiledbootstrap"

--- a/core-devel/gcc/01-runtime/defines
+++ b/core-devel/gcc/01-runtime/defines
@@ -68,10 +68,12 @@ if [[ "${CROSS:-$ARCH}" = *cross* ]]; then
 fi
 
 # MIPS is not yet happy with GNU hashing style.
-# Really?
-#if [[ "${CROSS:-$ARCH}" != mips* ]]; then
-#    AUTOTOOLS_AFTER+=" --with-linker-hash-style=gnu"
-#fi
+# Q: Really?
+# A: At least our MIPS-II (o32) still couldn't be built with GNU hash style.
+#    It is a ABI incompatibility, not an emulation error...
+if [[ "${CROSS:-$ARCH}" != mips32 ]]; then
+    AUTOTOOLS_AFTER+=" --with-linker-hash-style=gnu"
+fi
 
 # ARM and AArch64 specific.
 if [[ "${CROSS:-$ARCH}" = arm* ]]; then

--- a/core-libs/gmp/autobuild/prepare
+++ b/core-libs/gmp/autobuild/prepare
@@ -1,6 +1,9 @@
 # Apply custom flags to GMP build.
 export CC="gcc ${CPPFLAGS} ${CFLAGS} ${LDFLAGS}"
 export CXX="g++ ${CPPFLAGS} ${CFLAGS} ${LDFLAGS}"
+if [[ "${CROSS:-$ARCH}" = mips64el ]]; then
+        export ABI=64
+fi
 
 # Tweak configuration probing.
 cp /usr/share/automake-1.15/config.* "$SRCDIR"

--- a/core-libs/zlib/autobuild/build
+++ b/core-libs/zlib/autobuild/build
@@ -1,0 +1,3 @@
+./configure --prefix=/usr &&
+make $ABMK $MAKE_AFTER &&
+make install DESTDIR=$PKGDIR $MAKE_AFTER

--- a/core-libs/zlib/autobuild/prepare
+++ b/core-libs/zlib/autobuild/prepare
@@ -1,7 +1,0 @@
-# FAKE configure.
-export AUTOTOOLS_DEF="--prefix=/usr"
-export AUTOTOOLS_TARGET=""
-
-# -O3.
-export CFLAGS="${CFLAGS} -O3"
-export CXXFLAGS="${CXXFLAGS} -O3"

--- a/groups/build-core-all
+++ b/groups/build-core-all
@@ -12,7 +12,6 @@ core-libs/isl
 core-devel/gcc
 core-devel/binutils
 core-shells/bash
-core-devel/libtool
 core-libs/gdbm
 core-database/db
 core-perl/perl


### PR DESCRIPTION
This pull request contains:

- MIPS64EL support for AOSC OS Core.
- `zlib` fix for the `prepare` variable override makes no sense in newer versions of `autobuild`.
  - (Actually `zlib` does not use standard autoconf's `configure`)
- Remove an item in `groups/build-core-all` list that should have been removed.