### PR TITLE
gcc: remove --build= flag in gcc defines

### DIFF
--- a/core-devel/gcc/01-runtime/defines
+++ b/core-devel/gcc/01-runtime/defines
@@ -58,8 +58,7 @@ AUTOTOOLS_AFTER="--prefix=/usr \
                  --disable-multilib --disable-werror \
                  --enable-pie \
                  --enable-checking=release \
-                 --with-default-libstdcxx-abi=gcc4-compatible \
-                 --build=${ARCH_TARGET[$ARCH]}"
+                 --with-default-libstdcxx-abi=gcc4-compatible"
 
 # Cross.
 if [[ "${CROSS:-$ARCH}" = *cross* ]]; then


### PR DESCRIPTION
This is automatically added by autobuild now.