### PR TITLE
glibc: no strip

### DIFF
--- a/core-libs/glibc/autobuild/defines
+++ b/core-libs/glibc/autobuild/defines
@@ -64,6 +64,10 @@ fi
 # LTO breaks build with a warning-as-error, not taking the chances though.
 NOLTO=yes
 
+# Do not strip the library to provide sufficient symbols
+# to assist debuggers
+ABSTRIP=0
+
 LOCALEGENVER="20160914"
 
 # Merges locale-gen at Core 4.

--- a/core-libs/glibc/spec
+++ b/core-libs/glibc/spec
@@ -1,3 +1,3 @@
 VER=2.26
-REL=3
+REL=4
 SRCTBL="https://ftp.gnu.org/gnu/glibc/glibc-$VER.tar.xz"


### PR DESCRIPTION
Do not strip the library to provide sufficient symbols and hints for memory debuggers like Valgrind to work

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aosc-dev/aosc-os-core/53)
<!-- Reviewable:end -->
